### PR TITLE
disable certificate checking while making https connection

### DIFF
--- a/awesometts/service/base.py
+++ b/awesometts/service/base.py
@@ -520,6 +520,17 @@ class Service(object):
         assert method in ['GET', 'POST'], "method must be GET or POST"
         from urllib2 import urlopen, Request, quote
 
+        import ssl
+
+        try:
+            _create_unverified_https_context = ssl._create_unverified_context
+        except AttributeError:
+            # Legacy Python that doesn't verify HTTPS certificates by default
+            pass
+        else:
+            # Handle target environment that doesn't support HTTPS verification
+            ssl._create_default_https_context = _create_unverified_https_context
+
         targets = targets if isinstance(targets, list) else [targets]
         targets = [
             (target, None) if isinstance(target, basestring)


### PR DESCRIPTION
Disable certificate checking while making https connection. It requires alternate/beta build with newer python (available from https://apps.ankiweb.net/downloads/beta/). It fixes #4.

It's based on https://www.python.org/dev/peps/pep-0476/#opting-out - I've decided to skip completely certificate verification because those are plain audio files so verifying that they come from website has correct certificate doesn't make that much sense.