### PR TITLE
Make it possible to disable fuzzy-matching for OED

### DIFF
--- a/awesometts/service/base.py
+++ b/awesometts/service/base.py
@@ -497,7 +497,8 @@ class Service(object, metaclass=abc.ABCMeta):
 
     def net_stream(self, targets, require=None, method='GET',
                    awesome_ua=False, add_padding=False,
-                   custom_quoter=None, custom_headers=None):
+                   custom_quoter=None, custom_headers=None,
+                   allow_redirects=True):
         """
         Returns the raw payload string from the specified target(s).
         If multiple targets are specified, their resulting payloads are
@@ -518,6 +519,8 @@ class Service(object, metaclass=abc.ABCMeta):
         If add_padding is True, then some additional null padding will
         be added onto the stream returned. This is helpful for some web
         services that sometimes return MP3s that `mplayer` clips early.
+
+        To prevent redirects one can set allow_redirects to False.
         """
 
         assert method in ['GET', 'POST'], "method must be GET or POST"
@@ -601,6 +604,9 @@ class Service(object, metaclass=abc.ABCMeta):
                 value_error.got_mime = got_mime
                 value_error.wanted_mime = require['mime']
                 raise value_error
+
+            if not allow_redirects and response.geturl() != url:
+                raise ValueError("Request has been redirected")
 
             payload = response.read()
             response.close()


### PR DESCRIPTION
I added an option to disable fuzzy-matching. It may come in handy when creating a hierarchy of services to use (so those with better quality - like OED - first, some worse quality one as a fallback) using ordered groups.

The mechanism underneath uses a simple test to determine if there was a redirect to another address (like from /green-umbrella to /umbrella or /green). If there was, it is assumed to be a fuzzy-matched phrase and discarded (but only if the user disabled 'fuzzy-matching" option).

The "fuzzy-matching" option is enabled by default to match the current behavior.