### PR TITLE
Add a type check to error handling

### DIFF
--- a/awesometts/gui/generator.py
+++ b/awesometts/gui/generator.py
@@ -355,7 +355,9 @@ class BrowserGenerator(ServiceDialog):
 
             proc['counts']['fail'] += 1
 
-            message = exception.message
+            message = 'No message'
+            if hasattr(exception, 'message'):
+                message = exception.message
             if isinstance(message, str):
                 message = self._RE_WHITESPACE.sub(' ', message).strip()
 


### PR DESCRIPTION
Fixes the ticket at https://anki.tenderapp.com/discussions/add-ons/24212-anki-crashes-due-to-awesome-tts. Seems to be a simple issue with type checking.

A copy of the relevant stack trace is:

```
Caught exception: 
  File "C:\Users\wangy\AppData\Roaming\Anki2\addons21\900455869\gui\generator.py", line 404, in _accept_next 
    note=note) 
  File "C:\Users\wangy\AppData\Roaming\Anki2\addons21\900455869\router.py", line 438, in __call__ 
    callbacks['fail'](exception) 
  File "C:\Users\wangy\AppData\Roaming\Anki2\addons21\900455869\gui\generator.py", line 359, in fail 
    message = exception.message 
<class 'AttributeError'>: 'ValueError' object has no attribute 'message'
```