### PR TITLE
Solving incorrect MIME Type Error

### DIFF
--- a/awesometts/service/oxford.py
+++ b/awesometts/service/oxford.py
@@ -171,7 +171,7 @@ class Oxford(Service):
             self.net_download(
                 path,
                 sound_url,
-                require=dict(mime='binary/octet-stream', size=1024),
+                require=dict(mime='audio/mpeg', size=1024),
             )
         else:
             raise IOError(


### PR DESCRIPTION
Required MIME type changed in source code, now the module for Oxford Dictionary works perfectly