### PR TITLE
Set Add TTS button as non-default

### DIFF
--- a/awesometts/gui/common.py
+++ b/awesometts/gui/common.py
@@ -219,6 +219,8 @@ class Button(QtWidgets.QPushButton, _QtConnector, AbstractButton):
 
         self.setShortcut(sequence)
         self.setToolTip(self.tooltip_text(tooltip, sequence))
+        self.setDefault(False)
+        self.setAutoDefault(False)
 
         if style:
             self.setStyle(style)


### PR DESCRIPTION
With the button set as default, pressing Enter on the search field will also trigger AwesomeTTS's dialog.

I see gui.Button is not used anywhere else in the code, so setting the properties in the constructor shouldn't have unintended side effects on other things, as far as I can tell.