### PR TITLE
Fix deprecation warning to use `strip_html` instead of `stripHTML`

### DIFF
--- a/awesometts/text.py
+++ b/awesometts/text.py
@@ -55,7 +55,7 @@ RE_NEWLINEISH = re.compile(r'(\r|\n|<\s*/?\s*(br|div|p)(\s+[^>]*)?\s*/?\s*>)+',
 RE_SOUNDS = re.compile(r'\[sound:(.*?)\]')  # see also anki.sound._soundReg
 RE_WHITESPACE = re.compile(r'[\0\s]+', re.UNICODE)
 
-STRIP_HTML = anki.utils.stripHTML  # this also converts character entities
+STRIP_HTML = anki.utils.strip_html  # this also converts character entities
 
 
 class Sanitizer(object):  # call only, pylint:disable=too-few-public-methods


### PR DESCRIPTION
Warning: awesometts/text.py:58:stripHTML is deprecated: please use 'strip_html'

https://github.com/ankitects/anki/blob/main/pylib/anki/utils.py#L315=