### PR TITLE
Fix crash on config exit with new Anki version without the Qt5 compatibility shim

### DIFF
--- a/awesometts/gui/configurator.py
+++ b/awesometts/gui/configurator.py
@@ -279,7 +279,7 @@ class Configurator(Dialog):
             """Fixes original text and resets cursor to end of line."""
 
             filtered = self.fixup(original)
-            return aqt.qt.QValidator.Acceptable, filtered, len(filtered)
+            return aqt.qt.QValidator.State.Acceptable, filtered, len(filtered)
 
     _ui_tabs_text_mode_simple_spec.ucsv = _UniqueCharacterStringValidator()
 


### PR DESCRIPTION
Fixes this error when exiting the config window on recent Anki releases:
```
Caught exception:
Traceback (most recent call last):
  File "/Users/aurora/Library/Application Support/Anki2/addons21/1436550454/awesometts/gui/configurator.py", line 282, in validate
    return aqt.qt.QValidator.Acceptable, filtered, len(filtered)
AttributeError: type object 'QValidator' has no attribute 'Acceptable'
```
