### PR TITLE
Fix AttributeError with VocalWare

### DIFF
--- a/awesometts/router.py
+++ b/awesometts/router.py
@@ -464,7 +464,7 @@ class Router(object):
                     if lower == 'text':
                         return text
                     if lower == 'voice':
-                        return options['voice'].lower()
+                        return options['voice'].lower() if isinstance(options['voice'], str) else 'unknown'
 
                     try:
                         return note[key]  # exact field match


### PR DESCRIPTION
options['voice'] for VocalWare is nested dictionary instead of string. E.g. VocalWare ({'engine_id': 3, 'language_id': 1, 'voice_id': 4})

Fallback to 'unknown' to avoid an exception:

```
Caught exception:
Traceback (most recent call last):
  File "/home/foo/.local/share/Anki2/addons21/1436550454/awesometts/router.py", line 970, in _on_worker_signal
    self._threads[thread_id]['callback'](exception)
  File "/home/foo/.local/share/Anki2/addons21/1436550454/awesometts/router.py", line 547, in completion_callback
    callbacks['okay'](human(path))
  File "/home/foo/.local/share/Anki2/addons21/1436550454/awesometts/router.py", line 483, in human
    filename = RE_MUSTACHE.sub(substitute, want_human)
  File "..../awesometts/router.py", line 467, in substitute
    return options['voice'].lower()
AttributeError: 'dict' object has no attribute 'lower'
```

It's just a quick fix, file names with different language settings could override in a corner case. However, I have no short and universal solution to extract all the (meaningful) attributes to string.